### PR TITLE
feat: add extensibility fields and harden deployment defaults

### DIFF
--- a/charts/openclaw-helm/templates/_helpers.tpl
+++ b/charts/openclaw-helm/templates/_helpers.tpl
@@ -53,8 +53,8 @@ Container image reference. Uses digest when set, otherwise tag.
 Digest without algorithm prefix (e.g. bare hex) gets sha256: auto-prepended.
 */}}
 {{- define "openclaw-helm.image" -}}
-{{- if .Values.image.digest -}}
-{{- $d := .Values.image.digest | trim -}}
+{{- $d := (.Values.image.digest | default "" | trim) -}}
+{{- if $d -}}
 {{- if not (contains ":" $d) -}}
 {{- $d = printf "sha256:%s" $d -}}
 {{- end -}}

--- a/charts/openclaw-helm/templates/_helpers.tpl
+++ b/charts/openclaw-helm/templates/_helpers.tpl
@@ -50,10 +50,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/*
 Container image reference. Uses digest when set, otherwise tag.
+Digest without algorithm prefix (e.g. bare hex) gets sha256: auto-prepended.
 */}}
 {{- define "openclaw-helm.image" -}}
 {{- if .Values.image.digest -}}
-{{ .Values.image.repository }}@{{ .Values.image.digest }}
+{{- $d := .Values.image.digest | trim -}}
+{{- if not (contains ":" $d) -}}
+{{- $d = printf "sha256:%s" $d -}}
+{{- end -}}
+{{ .Values.image.repository }}@{{ $d }}
 {{- else -}}
 {{ .Values.image.repository }}:{{ .Values.image.tag }}
 {{- end -}}

--- a/charts/openclaw-helm/templates/_helpers.tpl
+++ b/charts/openclaw-helm/templates/_helpers.tpl
@@ -47,3 +47,14 @@ Selector labels
 app.kubernetes.io/name: {{ include "openclaw-helm.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Container image reference. Uses digest when set, otherwise tag.
+*/}}
+{{- define "openclaw-helm.image" -}}
+{{- if .Values.image.digest -}}
+{{ .Values.image.repository }}@{{ .Values.image.digest }}
+{{- else -}}
+{{ .Values.image.repository }}:{{ .Values.image.tag }}
+{{- end -}}
+{{- end }}

--- a/charts/openclaw-helm/templates/deployment.yaml
+++ b/charts/openclaw-helm/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
     {{- include "openclaw-helm.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "openclaw-helm.selectorLabels" . | nindent 6 }}
@@ -16,9 +20,13 @@ spec:
       labels:
         {{- include "openclaw-helm.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
       - name: init-config
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ include "openclaw-helm.image" . }}"
         command:
         - sh
         - -c
@@ -58,7 +66,7 @@ spec:
           mountPath: /tmp
       
       - name: init-skills
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ include "openclaw-helm.image" . }}"
         command:
         - sh
         - -c
@@ -83,7 +91,7 @@ spec:
       
       containers:
       - name: main
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ include "openclaw-helm.image" . }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - node
@@ -155,7 +163,13 @@ spec:
         - name: bash-aliases
           mountPath: /home/node/.bash_aliases
           subPath: bash_aliases
-      
+        {{- with .Values.extraVolumeMounts }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -180,3 +194,6 @@ spec:
           claimName: {{ include "openclaw-helm.fullname" . }}
       - name: tmp
         emptyDir: {}
+      {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/charts/openclaw-helm/templates/deployment.yaml
+++ b/charts/openclaw-helm/templates/deployment.yaml
@@ -9,6 +9,12 @@ spec:
   {{- with .Values.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
+  {{- else }}
+  {{- /* strategy: {} or null falls through with-guard;
+         default to Recreate because RWO PVCs cause
+         Multi-Attach errors during RollingUpdate upgrades */ -}}
+  strategy:
+    type: Recreate
   {{- end }}
   selector:
     matchLabels:

--- a/charts/openclaw-helm/templates/deployment.yaml
+++ b/charts/openclaw-helm/templates/deployment.yaml
@@ -75,6 +75,8 @@ spec:
           cd /home/node/.openclaw/workspace
           {{- range .Values.skills }}
           if [ ! -d "skills/{{ . }}" ]; then
+            # Design Decision: || true kept intentionally so one failed skill does not block pod startup;
+            # error logging improvement deferred to a follow-up PR
             npx -y clawhub install "{{ . }}" --no-input || true
           fi
           {{- end }}

--- a/charts/openclaw-helm/values.yaml
+++ b/charts/openclaw-helm/values.yaml
@@ -7,10 +7,11 @@ image:
 replicas: 1
 
 # strategy controls the deployment update strategy
-# Use Recreate for RWO PVC (e.g. EBS) to avoid Multi-Attach errors
-strategy: {}
-# strategy:
-#   type: Recreate
+# Recreate is required for RWO PVC (default on most cloud providers) to avoid
+# Multi-Attach errors during helm upgrade. Override to RollingUpdate only if
+# your StorageClass supports RWX (ReadWriteMany).
+strategy:
+  type: Recreate
 
 resources:
   limits:

--- a/charts/openclaw-helm/values.yaml
+++ b/charts/openclaw-helm/values.yaml
@@ -1,9 +1,16 @@
 image:
   repository: ghcr.io/openclaw/openclaw
   tag: "2026.3.28"
+  digest: ""    # if set, overrides tag (e.g. sha256:abc123...)
   pullPolicy: IfNotPresent
 
 replicas: 1
+
+# strategy controls the deployment update strategy
+# Use Recreate for RWO PVC (e.g. EBS) to avoid Multi-Attach errors
+strategy: {}
+# strategy:
+#   type: Recreate
 
 resources:
   limits:
@@ -106,3 +113,17 @@ tolerations: []
 
 # affinity defines advanced node/pod scheduling rules
 affinity: {}
+
+# podSecurityContext sets pod-level security attributes (e.g. fsGroup for volume permissions)
+podSecurityContext: {}
+# podSecurityContext:
+#   fsGroup: 1000
+
+# extraContainers adds sidecar containers to the pod
+extraContainers: []
+
+# extraVolumeMounts adds additional volume mounts to the main container
+extraVolumeMounts: []
+
+# extraVolumes adds additional volumes to the pod
+extraVolumes: []


### PR DESCRIPTION
## Summary

Add standard Helm extensibility fields to support advanced deployment scenarios (Tailscale sidecars, shared volumes, custom security contexts) and harden deployment defaults for safety.

### New Values Fields

| Field | Type | Default | Purpose |
|-------|------|---------|---------|
| `image.digest` | string | `""` | Use digest-based image refs for reproducibility; bare hex is auto-prefixed with `sha256:` |
| `strategy` | object | `type: Recreate` | Deployment update strategy (see breaking change below) |
| `podSecurityContext` | object | `{}` | Pod-level security attributes (e.g. `fsGroup` for EBS volumes) |
| `extraContainers` | list | `[]` | Inject sidecar containers alongside the main container |
| `extraVolumeMounts` | list | `[]` | Additional volume mounts on the main container |
| `extraVolumes` | list | `[]` | Additional volumes for the pod |

`nodeSelector`, `tolerations`, and `affinity` were already wired in the deployment template but lacked values.yaml declarations — they are now properly declared with documentation.

### Other Changes

- **`openclaw-helm.image` helper**: Consolidates 3 duplicated `repository:tag` references into a single template. Supports digest with auto `sha256:` prefix and whitespace trimming.
- **`checksum/config` annotation**: Triggers pod restart when ConfigMap content changes during `helm upgrade`.
- **`strategy` fallback**: `strategy: {}` or `null` falls back to `Recreate` (not Kubernetes default `RollingUpdate`) via an `else` branch with explanatory Helm comment.
- **CI**: Simplify release notes in GitHub Actions workflow.

## ⚠️ Breaking Change

**Default deployment strategy changed from RollingUpdate to Recreate.**

Previously, the chart did not set a strategy (Kubernetes defaults to `RollingUpdate`). This causes `Multi-Attach` errors on RWO PVCs — the default StorageClass on most cloud providers — during `helm upgrade`, because `RollingUpdate` creates a new pod before terminating the old one. Even with `replicas: 1`, the default `maxSurge: 1` triggers this.

The new default `strategy.type: Recreate` prevents this by terminating the old pod first. If your StorageClass supports RWX (ReadWriteMany), you can override back to `RollingUpdate`:

```yaml
strategy:
  type: RollingUpdate
```

## Test Plan

- [x] `helm template` renders correctly with default values
- [x] `helm template` with `image.digest` set produces correct `repo@sha256:...` reference
- [x] `helm template` with `extraContainers` produces valid sidecar at correct YAML level
- [x] Deployed to test environment (merlin) with `1.5.0-rc.2` — pod running, all fields verified
- [x] Verified `strategy: Recreate` applied, `auth.token` synced, health check passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)