### PR TITLE
fix: preserve gateway token across helm upgrades

### DIFF
--- a/charts/openclaw-helm/templates/deployment.yaml
+++ b/charts/openclaw-helm/templates/deployment.yaml
@@ -37,18 +37,20 @@ spec:
         - sh
         - -c
         - |
+          set -e
           mkdir -p /home/node/.openclaw
           [ -f /home/node/.openclaw/openclaw.json ] || cp /config/openclaw.json /home/node/.openclaw/openclaw.json
-          # Sync gateway.remote.token to match OPENCLAW_GATEWAY_TOKEN (if set)
-          # gateway reads auth token from env var first (env-first precedence), so auth.token in config is not needed
+          # Sync gateway.auth.token to match the Secret value (if set).
+          # The gateway process uses config-first precedence when OPENCLAW_SERVICE_KIND=gateway,
+          # so auth.token in config takes priority over the env var.
           if [ -n "$OPENCLAW_GATEWAY_TOKEN" ]; then
             node -e "
               const fs = require('fs');
               const p = '/home/node/.openclaw/openclaw.json';
               const c = JSON.parse(fs.readFileSync(p));
               c.gateway = c.gateway || {};
-              c.gateway.remote = c.gateway.remote || {};
-              c.gateway.remote.token = process.env.OPENCLAW_GATEWAY_TOKEN;
+              c.gateway.auth = c.gateway.auth || {};
+              c.gateway.auth.token = process.env.OPENCLAW_GATEWAY_TOKEN;
               fs.writeFileSync(p, JSON.stringify(c, null, 2));
             "
           fi
@@ -61,7 +63,7 @@ spec:
               {{- else }}
               name: {{ .Values.gateway.token.secretName }}
               {{- end }}
-              key: token
+              key: OPENCLAW_GATEWAY_TOKEN
               optional: true
         volumeMounts:
         - name: config

--- a/charts/openclaw-helm/templates/secret.yaml
+++ b/charts/openclaw-helm/templates/secret.yaml
@@ -1,13 +1,19 @@
 {{- if .Values.gateway.token.generate }}
+{{- $secretName := printf "%s-gateway-token" (include "openclaw-helm.fullname" .) }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "openclaw-helm.fullname" . }}-gateway-token
+  name: {{ $secretName }}
   labels:
     {{- include "openclaw-helm.labels" . | nindent 4 }}
   annotations:
     "helm.sh/resource-policy": keep
 type: Opaque
 data:
+  {{- if and $existingSecret $existingSecret.data (index $existingSecret.data "OPENCLAW_GATEWAY_TOKEN") }}
+  OPENCLAW_GATEWAY_TOKEN: {{ index $existingSecret.data "OPENCLAW_GATEWAY_TOKEN" }}
+  {{- else }}
   OPENCLAW_GATEWAY_TOKEN: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary
Use Helm `lookup` to retain existing gateway token Secret instead of regenerating on every `helm upgrade`.

## Problem
`randAlphaNum 32` is re-evaluated on every template render, overwriting the Secret on each upgrade. The `helm.sh/resource-policy: keep` annotation only prevents deletion on uninstall, not overwrites on upgrade.

This causes all paired Control UI sessions to lose their token after every `helm upgrade`.

## Fix
Check if the Secret already exists via `lookup`. If it does, reuse the existing token. Only generate a new random token on first install.

This is the standard Helm pattern used by bitnami, ingress-nginx, and other charts for generated secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)