### PR TITLE
refactor: remove hard-coded init-plugins in favor of extraInitContainers

### DIFF
--- a/charts/openclaw-helm/templates/deployment.yaml
+++ b/charts/openclaw-helm/templates/deployment.yaml
@@ -116,6 +116,10 @@ spec:
           mountPath: /home/node/.openclaw
       {{- end }}
 
+      {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+
       containers:
       - name: main
         image: "{{ include "openclaw-helm.image" . }}"

--- a/charts/openclaw-helm/templates/deployment.yaml
+++ b/charts/openclaw-helm/templates/deployment.yaml
@@ -98,7 +98,24 @@ spec:
           mountPath: /home/node/.openclaw
         - name: tmp
           mountPath: /tmp
-      
+
+      {{- if .Values.plugins }}
+      - name: init-plugins
+        image: "{{ include "openclaw-helm.image" . }}"
+        command:
+        - sh
+        - -c
+        - |
+          {{- range .Values.plugins }}
+          if [ ! -d "/home/node/.openclaw/extensions/{{ . }}" ]; then
+            node dist/index.js plugins install "clawhub:{{ . }}" || echo "[WARN] Failed to install plugin: {{ . }}"
+          fi
+          {{- end }}
+        volumeMounts:
+        - name: data
+          mountPath: /home/node/.openclaw
+      {{- end }}
+
       containers:
       - name: main
         image: "{{ include "openclaw-helm.image" . }}"

--- a/charts/openclaw-helm/templates/deployment.yaml
+++ b/charts/openclaw-helm/templates/deployment.yaml
@@ -99,23 +99,6 @@ spec:
         - name: tmp
           mountPath: /tmp
 
-      {{- if .Values.plugins }}
-      - name: init-plugins
-        image: "{{ include "openclaw-helm.image" . }}"
-        command:
-        - sh
-        - -c
-        - |
-          {{- range .Values.plugins }}
-          if [ ! -d "/home/node/.openclaw/extensions/{{ . }}" ]; then
-            node dist/index.js plugins install "clawhub:{{ . }}" || echo "[WARN] Failed to install plugin: {{ . }}"
-          fi
-          {{- end }}
-        volumeMounts:
-        - name: data
-          mountPath: /home/node/.openclaw
-      {{- end }}
-
       {{- with .Values.extraInitContainers }}
         {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/openclaw-helm/values.yaml
+++ b/charts/openclaw-helm/values.yaml
@@ -122,6 +122,9 @@ podSecurityContext: {}
 # podSecurityContext:
 #   fsGroup: 1000
 
+# extraInitContainers adds init containers after the built-in ones (init-config, init-skills, init-plugins)
+extraInitContainers: []
+
 # extraContainers adds sidecar containers to the pod
 extraContainers: []
 

--- a/charts/openclaw-helm/values.yaml
+++ b/charts/openclaw-helm/values.yaml
@@ -88,8 +88,6 @@ skills:
   - weather
   - gog
 
-plugins: []
-
 gateway:
   token:
     generate: true    # auto-generate gateway token Secret on install, retained on uninstall
@@ -122,7 +120,7 @@ podSecurityContext: {}
 # podSecurityContext:
 #   fsGroup: 1000
 
-# extraInitContainers adds init containers after the built-in ones (init-config, init-skills, init-plugins)
+# extraInitContainers adds init containers after the built-in ones (init-config, init-skills)
 extraInitContainers: []
 
 # extraContainers adds sidecar containers to the pod

--- a/charts/openclaw-helm/values.yaml
+++ b/charts/openclaw-helm/values.yaml
@@ -88,6 +88,8 @@ skills:
   - weather
   - gog
 
+plugins: []
+
 gateway:
   token:
     generate: true    # auto-generate gateway token Secret on install, retained on uninstall


### PR DESCRIPTION
## Summary
- Remove the hard-coded `init-plugins` init container from `deployment.yaml`, keeping the chart generic and decoupled from specific plugin identifiers
- Remove the `plugins` field from `values.yaml` — plugin installation is no longer a first-class chart concern
- Promote `extraInitContainers` as the intended mechanism for injecting custom init logic (e.g., plugin installation) from environment-specific configuration (e.g., `moltbot-env`)
- The chart now provides the infrastructure (`extraInitContainers` renders after `init-config` and `init-skills`), while the actual plugin installation script lives in the consuming environment's values

## Migration

Consumers that previously used the `plugins` field should move their plugin installation to `extraInitContainers` in their environment values:

```yaml
extraInitContainers:
  - name: init-plugins
    image: "ghcr.io/openclaw/openclaw:2026.4.14"
    command:
      - sh
      - -c
      - |
        set -e
        mkdir -p /home/node/.openclaw/extensions
        FAILED=0
        for PLUGIN in marxbiotech-moltbot-utils; do
          if [ ! -d "/home/node/.openclaw/extensions/${PLUGIN}" ]; then
            echo "[INFO] Installing plugin: ${PLUGIN}"
            if ! node dist/index.js plugins install "clawhub:${PLUGIN}"; then
              echo "[ERROR] Failed to install plugin: ${PLUGIN}"
              FAILED=$((FAILED + 1))
            fi
          else
            echo "[INFO] Plugin already installed: ${PLUGIN}"
          fi
        done
        if [ "$FAILED" -gt 0 ]; then
          echo "[FATAL] $FAILED plugin(s) failed to install"
          exit 1
        fi
    env:
      - name: HOME
        value: /tmp
      - name: NPM_CONFIG_CACHE
        value: /tmp/.npm
    volumeMounts:
      - name: data
        mountPath: /home/node/.openclaw
      - name: tmp
        mountPath: /tmp
```

## Test plan
- [ ] Deploy with `extraInitContainers` containing the init-plugins block and verify plugins install correctly
- [ ] Verify plugins are skipped on subsequent pod restarts (idempotent)
- [ ] Deploy without `extraInitContainers` and verify clean startup with only `init-config` and `init-skills`
- [ ] Trigger a plugin installation failure and confirm the pod does not start
- [ ] Verify the `plugins` field is no longer recognized by the chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)