### PR TITLE
feat: add support for extraInitContainers in deployment template

### DIFF
--- a/charts/openclaw-helm/templates/deployment.yaml
+++ b/charts/openclaw-helm/templates/deployment.yaml
@@ -98,7 +98,11 @@ spec:
           mountPath: /home/node/.openclaw
         - name: tmp
           mountPath: /tmp
-      
+
+      {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+
       containers:
       - name: main
         image: "{{ include "openclaw-helm.image" . }}"

--- a/charts/openclaw-helm/values.yaml
+++ b/charts/openclaw-helm/values.yaml
@@ -120,6 +120,9 @@ podSecurityContext: {}
 # podSecurityContext:
 #   fsGroup: 1000
 
+# extraInitContainers adds init containers after the built-in ones (init-config, init-skills)
+extraInitContainers: []
+
 # extraContainers adds sidecar containers to the pod
 extraContainers: []
 


### PR DESCRIPTION
## Summary
This PR introduces the `extraInitContainers` field to the deployment template, allowing users to inject custom initialization logic (e.g., plugin installation, complex environment setup) after the built-in init containers.

## Key Changes
- Added `extraInitContainers` block in `templates/deployment.yaml` between `init-skills` and the main `containers`.
- Defined `extraInitContainers: []` as a default in `values.yaml` with explanatory comments.

This provides the necessary hook for environment-specific customizations while keeping the core chart generic and stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)